### PR TITLE
[diff2html] feat add syntax highlighting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
     less: {
       production: {
         files: {
-          "public/css/styles.css": ["public/less/styles.less", "public/vendor/css/animate.css", "public/less/d2h.less"],
+          "public/css/styles.css": ["public/less/styles.less", "public/vendor/css/animate.css", "public/less/d2h.less", "public/less/highlight.less"],
           "components/commit/commit.css": ["components/commit/commit.less"],
           "components/commitdiff/commitdiff.css": ["components/commitdiff/commitdiff.less"],
           "components/graph/graph.css": ["components/graph/graph.less"],
@@ -185,7 +185,7 @@ module.exports = function(grunt) {
     });
     b.add('./public/source/main.js');
     b.require('./public/source/main.js', { expose: 'ungit-main' });
-    
+
     b.require('./public/source/components.js', { expose: 'ungit-components' });
     b.require('./public/source/program-events.js', { expose: 'ungit-program-events' });
     b.require('./public/source/navigation.js', { expose: 'ungit-navigation' });
@@ -204,6 +204,7 @@ module.exports = function(grunt) {
     b.require('util', { expose: 'util' });
     b.require('path', { expose: 'path' });
     b.require('diff2html', { expose: 'diff2html' });
+    b.require('highlight.js', { expose: 'highlight.js' });
     var outFile = fs.createWriteStream('./public/js/ungit.js');
     outFile.on('close', function() {
       done();

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "forever-monitor": "~1.1.0",
     "getmac": "~1.0.7",
     "hasher": "~1.2.0",
+    "highlight.js": "~8.6.0",
     "keen.io": "~0.1.3",
     "knockout": "~3.3.0",
     "lodash": "~3.6.0",

--- a/public/less/d2h.less
+++ b/public/less/d2h.less
@@ -13,6 +13,8 @@
   margin: 0 auto;
   text-align: left;
   width: 100%;
+  color: rgb(183, 183, 183);
+  background: #1E1E1E;
 }
 
 .d2h-file-wrapper {
@@ -61,11 +63,14 @@
   border-collapse: collapse;
   font-family: 'Source Code Pro';
   font-size: 12px;
-  height: 19px;
   width: 100%;
   tbody > tr > td {
     padding: 0px;
     border-spacing: 0px;
+    white-space: nowrap;
+  }
+  tbody > tr > td:last-child {
+    width: 100%;
   }
 }
 
@@ -89,7 +94,6 @@
   padding-left: 10px;
   padding-right: 10px;
   height: 19px;
-  margin-left: 80px;
 }
 
 .d2h-code-side-line {
@@ -97,93 +101,61 @@
   padding-left: 5px;
   padding-right: 5px;
   height: 19px;
-  margin-left: 50px;
 }
 
 .d2h-code-line del,
 .d2h-code-side-line del {
+  height: 19px;
   display: inline-block;
-  margin-top: -1px;
   text-decoration: none;
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: rgba(255, 0, 0, 0.2);
 }
 
 .d2h-code-line ins,
 .d2h-code-side-line ins {
+  height: 19px;
   display: inline-block;
-  margin-top: -1px;
   text-decoration: none;
-  background-color: rgba(255, 255, 255, 0.6);
+  background-color: rgba(155, 185, 85, 0.2);
 }
 
 .line-num1 {
-  display: inline-block;
-  float: left;
   width: 30px;
-  overflow: hidden;
+  display: inline-block;
   text-overflow: ellipsis;
 }
 
 .line-num2 {
-  display: inline-block;
-  float: right;
   width: 30px;
-  overflow: hidden;
+  display: inline-block;
   text-overflow: ellipsis;
 }
 
-.d2h-code-linenumber {
-  position: absolute;
-  width: 2%;
-  min-width: 65px;
-  padding-left: 10px;
-  padding-right: 10px;
+.d2h-code-linenumber, .d2h-code-side-linenumber {
+  padding: 0 4px !important;
   height: 19px;
-  background-color: #fff;
-  color: rgba(0, 0, 0, 0.3);
+  background-color: #1E1E1E;
+  color: #5A5A5A;
   text-align: right;
-  border: solid #eeeeee;
-  border-width: 0 1px 0 1px;
+  border: solid #1A1A1A;
+  border-width: 0 1px 0 0;
   cursor: pointer;
-}
-
-.d2h-cntx {
-  color: rgba(255, 255, 255, 0.3);
-}
-
-.d2h-code-side-linenumber, .d2h-code-linenumber {
-  position: absolute;
-  width: 52px;
-  text-align: center;
-  height: 19px;
-  background-color: rgba(114, 122, 131, 1);
-  color: rgba(0, 0, 0, 0.5);
-  border-width: 0 1px 0 1px;
-  cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  border-left: 1px solid rgba(0, 0, 0, 0.34);
-  border-right: 1px solid rgba(0, 0, 0, 0.34);
+  &.d2h-del {
+    color: #ccc;
+  }
+  &.d2h-ins {
+    color: #ccc;
+  }
 }
 
 .d2h-del {
-  background-color: #E86756;
-  color: #FFFFFF;
-
-  &.d2h-code-side-linenumber {
-    color: rgba(0, 0, 0, 0.5);
-  }
+  background-color: rgba(255, 0, 0, 0.2);
 }
 
 .d2h-ins {
-  background-color: #66F27B;
-  color: #000000;
-
-  &.d2h-code-side-linenumber {
-    color: rgba(0, 0, 0, 0.5);
-  }
+  background-color: rgba(155, 185, 85, 0.2);
 }
 
 .d2h-info {
-  color: rgba(255, 255, 255, 0.3);
+  opacity: .5;
 }

--- a/public/less/highlight.less
+++ b/public/less/highlight.less
@@ -1,0 +1,123 @@
+/*
+
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+
+*/
+/*
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #333;
+  background: #f8f8f8;
+  -webkit-text-size-adjust: none;
+}
+*/
+.hljs-comment,
+.diff .hljs-header {
+  color: #608B4E;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.css .rule .hljs-keyword,
+.hljs-winutils,
+.nginx .hljs-title,
+.hljs-subst,
+.hljs-request,
+.hljs-status {
+  color: #569CD6;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-hexcolor,
+.ruby .hljs-constant {
+  color: #CE9178;
+}
+
+.hljs-string,
+.hljs-tag .hljs-value,
+.hljs-doctag,
+.tex .hljs-formula {
+  color: #CE9178;
+}
+
+.hljs-title,
+.hljs-id,
+.scss .hljs-preprocessor {
+  color: #900;
+  font-weight: bold;
+}
+
+.hljs-list .hljs-keyword,
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-class .hljs-title,
+.hljs-type,
+.vhdl .hljs-literal,
+.tex .hljs-command {
+  color: #D7BA7D;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-tag .hljs-title,
+.hljs-rule .hljs-property,
+.django .hljs-tag .hljs-keyword {
+  color: #D7BA7D;
+  font-weight: normal;
+}
+
+.hljs-attribute,
+.hljs-variable,
+.lisp .hljs-body,
+.hljs-name {
+  color: #9CDCFE;
+}
+
+.hljs-regexp {
+  color: #B46695;
+}
+
+.hljs-symbol,
+.ruby .hljs-symbol .hljs-string,
+.lisp .hljs-keyword,
+.clojure .hljs-keyword,
+.scheme .hljs-keyword,
+.tex .hljs-special,
+.hljs-prompt {
+  color: #990073;
+}
+
+.hljs-built_in {
+  color: #0086b3;
+}
+
+.hljs-preprocessor,
+.hljs-pragma,
+.hljs-pi,
+.hljs-doctype,
+.hljs-shebang,
+.hljs-cdata {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.diff .hljs-change {
+  background: #0086b3;
+}
+
+.hljs-chunk {
+  color: #aaa;
+}

--- a/source/config.js
+++ b/source/config.js
@@ -99,7 +99,9 @@ var defaultConfig = {
   // possible to perform those actions even when you have a dirty working directory.
   autoStashAndPop: true,
 
-  fileSeparator: path.sep
+  fileSeparator: path.sep,
+  // Automatic syntax highlighting for diffs
+  syntaxhighlight: false,
 };
 
 function getUserHome() {
@@ -148,7 +150,8 @@ var argv = yargs
 .describe('pluginConfigs', 'No supported as a command line argument, use ungitrc config file.  See README.md')
 .describe('autoStashAndPop', 'Used for development purposes')
 .describe('dev', 'Automatically does stash -> operation -> stash pop when you checkout, reset or cherry pick')
-.describe('fileSeparator', 'OS dependent file separator');
+.describe('fileSeparator', 'OS dependent file separator')
+.describe('syntaxhighlight', 'Automatic syntax highlighting for diffs');
 
 // For testing, $0 is grunt.  For credential-parser test, $0 is node
 // When ungit is started normaly, $0 == ungit, and non-hyphenated options exists, show help and exit.


### PR DESCRIPTION
Currently it uses the github colors but they aren't optimised for ungit yet. Maybe someone else can help.
This does not need to go into the diff2html PR. I just wanted to show how it would look like.

![image](https://cloud.githubusercontent.com/assets/4009570/7892438/b20342ee-0654-11e5-964a-396d1bef428e.png)

fixes FredrikNoren/ungit#500
