### PR TITLE
[diff2html] Fix new open diff discarded

### DIFF
--- a/source/git.js
+++ b/source/git.js
@@ -212,8 +212,9 @@ git.diffFile = function(repoPath, filename, sha1) {
       var file = status.files[filename];
       var filePath = path.join(repoPath, filename);
       if (!file && !sha1) {
-        // if file or folder doesn't exist or sha hasn't been passed in.
-        task.setResult(null, []);
+        if (fs.existsSync(path.join(repoPath, filename))) task.setResult(null, []);
+        else task.setResult({ error: 'No such file: ' + filename, errorCode: 'no-such-file' });
+        // If the file is new or if it's a directory, i.e. a submodule
       } else {
         var gitCommands;
         var allowedCodes = null;  // default is [0]


### PR DESCRIPTION
this reverts the previous commit https://github.com/codingtwinky/ungit/commit/a7013dcfbb2dbee3e1cebb7a0bccd30d4a635d61 and uses the old error checking from https://github.com/FredrikNoren/ungit/blob/1c98eb5c36aaea0dbb26fcda3b60481244c6f137/components/textdiff/textdiff.js#L46-L54

@codingtwinky you can return a thruthly value from a server request which contained an error to indicate that the client handled the error. see https://github.com/FredrikNoren/ungit/blob/1c98eb5c36aaea0dbb26fcda3b60481244c6f137/public/source/server.js#L97
