### PR TITLE
[ahead/behind] parse git result on serverside

### DIFF
--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -88,14 +88,14 @@ StagingViewModel.prototype.setAheadAndBehind = function() {
       console.log("error while acquiring ahead info", err);
       return;
     }
-    self.ahead(ahead ? ahead.split('\n') : []);
+    self.ahead(ahead);
   });
   this.server.get('/behind', { path: this.repoPath }, function(err, behind) {
     if (err) {
       console.log("error while acquiring behind info", err);
       return;
     }
-    self.behind(behind ? behind.split('\n') : []);
+    self.behind(behind);
   });
 }
 StagingViewModel.prototype.updateNode = function(parentElement) {

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -679,15 +679,15 @@ exports.registerApi = function(env) {
 
   app.get(exports.pathPrefix + '/behind', ensureAuthenticated, function(req, res) {
     git(['rev-list', "HEAD..master"], req.query['path'])
-      .fail(function() { res.json(0); })
-      .done(function(result) { res.json(result ? result.trim() : 0); })
+      .fail(function() { res.json([]); })
+      .done(function(result) { res.json(result ? result.trim().split('\n') : []); })
       .start();
   });
 
   app.get(exports.pathPrefix + '/ahead', ensureAuthenticated, function(req, res) {
     git(['rev-list', "master..HEAD"], req.query['path'])
-      .fail(function() { res.json(0); })
-      .done(function(result) { res.json(result ? result.trim() : 0); })
+      .fail(function() { res.json([]); })
+      .done(function(result) { res.json(result ? result.trim().split('\n') : []); })
       .start();
   });
 

--- a/test/spec.git-api.branching.js
+++ b/test/spec.git-api.branching.js
@@ -96,6 +96,22 @@ describe('git-api branching', function () {
 			done();
 		});
 	});
+	
+	it('HEAD should not be before master branch', function(done) {
+		common.get(req, '/ahead', { path: testDir }, function(err, res) {
+			if (err) return done(err);
+			expect(res.body.length).to.be(0);
+			done();
+		});
+	});
+
+	it('HEAD should not be behind master branch', function(done) {
+		common.get(req, '/behind', { path: testDir }, function(err, res) {
+			if (err) return done(err);
+			expect(res.body.length).to.be(0);
+			done();
+		});
+	});
 
 	var commitMessage3 = 'Commit 3';
 	var testFile2 = "testfile2.txt";
@@ -105,6 +121,22 @@ describe('git-api branching', function () {
 			function(done) { common.post(req, '/testing/createfile', { file: path.join(testDir, testFile2) }, done); },
 			function(done) { common.post(req, '/commit', { path: testDir, message: commitMessage3, files: [testFile2] }, done); }
 		], done);
+	});
+
+	it('HEAD should be one commit ahead of master branch', function(done) {
+		common.get(req, '/ahead', { path: testDir }, function(err, res) {
+			if (err) return done(err);
+			expect(res.body.length).to.be(1);
+			done();
+		});
+	});
+
+	it('HEAD should not be behind master branch', function(done) {
+		common.get(req, '/behind', { path: testDir }, function(err, res) {
+			if (err) return done(err);
+			expect(res.body.length).to.be(0);
+			done();
+		});
 	});
 
 	it('log should show both branches and all commits', function(done) {
@@ -169,6 +201,31 @@ describe('git-api branching', function () {
 		});
 	});
 
+	var commitMessage2 = 'Commit 2';
+
+	it('should be possible to commit and checkout the previous commit', function(done) {
+		async.series([
+			function(done) { common.post(req, '/commit', { path: testDir, message: commitMessage2, files: [testFile1] }, done); },
+			function(done) { common.post(req, '/checkout', { path: testDir, name: 'HEAD~1' }, done); }
+		], done);
+	});
+
+	it('HEAD should not be ahead of master branch', function(done) {
+		common.get(req, '/ahead', { path: testDir }, function(err, res) {
+			if (err) return done(err);
+			expect(res.body.length).to.be(0);
+			done();
+		});
+	});
+
+	it('HEAD should be one commit behind master branch', function(done) {
+		common.get(req, '/behind', { path: testDir }, function(err, res) {
+			if (err) return done(err);
+			expect(res.body.length).to.be(1);
+			done();
+		});
+	});
+
 
 	it('should be possible to create a tag', function(done) {
 		common.post(req, '/tags', { path: testDir, name: 'v1.0' }, done);
@@ -199,11 +256,16 @@ describe('git-api branching', function () {
 	});
 
 	it('branch should be removed', function(done) {
-		common.get(req, '/branches', { path: testDir }, function(err, res) {
-			if (err) return done(err);
-			expect(res.body.length).to.be(1);
-			done();
-		});
+		async.series([
+			function(done) { common.post(req, '/checkout', { path: testDir, name: 'master' }, done); },
+			function(done) {
+				common.get(req, '/branches', { path: testDir }, function(err, res) {
+					if (err) return done(err);
+					expect(res.body.length).to.be(1);
+					done();
+				});
+			}
+		], done);
 	});
 
 	after(function(done) {


### PR DESCRIPTION
ensure that the return type is always an array. before it was either a string or a number.

adding tests.
